### PR TITLE
Refactor: Organize FastAPI routes using APIRouter

### DIFF
--- a/src/routers/series_router.py
+++ b/src/routers/series_router.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from src.schemas import schemas
+from src.infra.sqlalchemy.repositorios.series import RepositorioSerie
+from src.infra.sqlalchemy.config.database import get_db
+
+router = APIRouter(prefix="/series", tags=["series"])
+
+@router.post('/')
+def criar_serie(serie: schemas.Serie, db: Session = Depends(get_db)):
+    serie_criada = RepositorioSerie(db).criar(serie)
+    return serie_criada
+
+@router.get('/')
+def listar_serie(db: Session = Depends(get_db)):
+    return RepositorioSerie(db).listar()
+
+@router.get('/{series_id}')
+def obter_serie(serie_id: int, db: Session = Depends(get_db)):
+    serie = RepositorioSerie(db).obter(serie_id)
+    return serie
+
+@router.delete('/{series_id}')
+def remover_serie(serie_id: int, db: Session = Depends(get_db)):
+    RepositorioSerie(db).remover(serie_id)
+    return {'Removido com sucesso!'}

--- a/src/server.py
+++ b/src/server.py
@@ -1,32 +1,10 @@
-from fastapi import FastAPI, Depends
-from src.infra.sqlalchemy.config.database import criar_db, get_db
-from . import schemas
-from sqlalchemy.orm import Session
-from src.infra.sqlalchemy.repositorios.series import RepositorioSerie
-
+from fastapi import FastAPI
+from src.infra.sqlalchemy.config.database import criar_db
+from src.routers.series_router import router as series_router
 
 
 criar_db()
 
 
 app = FastAPI()
-
-@app.pos('/series')
-def criar_serie(serie: schemas.Serie, db: Session = Depends(get_db)):
-    serie_criada = RepositorioSerie(db).criar(serie)
-    return serie_criada,
-
-@app.get('/series')
-def listar_serie(db: Session = Depends(get_db)):
-    return RepositorioSerie(db).listar()
-
-@app.get('/series/{series_id}')
-def obter_serie(serie_id: int, db: Session = Depends(get_db)):
-    serie = RepositorioSerie(db).obter(serie_id)
-    return serie
-
-
-@app.delete('/series/{series_id}')
-def remover_serie(serie_id: int, db: Session = Depends(get_db)):
-    RepositorioSerie(db).remover(serie_id)
-    return {'Removido com sucesso!'}
+app.include_router(series_router)


### PR DESCRIPTION
Moved series-related endpoints from the main server file (`src/server.py`) to a dedicated router (`src/routers/series_router.py`).

This change improves code organization and maintainability by grouping related routes. The main application now includes this router. All functionalities remain the same.